### PR TITLE
Add CI for pre-built images

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: edge-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   packages: write
@@ -12,6 +16,7 @@ permissions:
 jobs:
   build-push:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -54,3 +59,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           provenance: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -1,0 +1,55 @@
+name: Edge build
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+            docker.io/${{ github.repository }}
+          tags: |
+            type=edge,branch=main
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -53,3 +53,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          provenance: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   build-push:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -57,3 +58,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           provenance: false
+          cache-from: type=gha,scope=release
+          cache-to: type=gha,mode=max,scope=release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release build
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+            docker.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,3 +56,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          provenance: false

--- a/README.md
+++ b/README.md
@@ -101,23 +101,42 @@ pip install -r requirements.txt
 python ifc2citygml.py --help
 ```
 
-### Option 3: Docker Installation
+### Option 3: Docker
 
-A Dockerfile is provided for containerized usage:
+Pre-built multi-arch images (linux/amd64, linux/arm64) are available from:
+
+- **GHCR:** `ghcr.io/tum-gis/ifc-to-citygml3`
+- **DockerHub:** `docker.io/tum-gis/ifc-to-citygml3`
+
+**Available tags:**
+
+| Tag | Description |
+|-----|-------------|
+| `edge` | Latest build from `main` branch (development) |
+| `1.2.3` | Specific release version |
+| `1.2` | Latest patch of a minor version |
+| `1` | Latest minor/patch of a major version |
+| `latest` | Most recent release |
 
 ```bash
-# Build the Docker image
-docker build -t ifc-to-citygml3 .
+# Pull the image
+docker pull ghcr.io/tum-gis/ifc-to-citygml3:latest
 
 # Run the converter and show help (Linux / MacOS)
-docker run --rm -v $(pwd):/app ifc-to-citygml3 -h
+docker run --rm -v $(pwd):/app ghcr.io/tum-gis/ifc-to-citygml3:latest -h
 # Run the converter and show help (Windows Powershell)
-docker run --rm -v ${PWD}:/app ifc-to-citygml3 -h
+docker run --rm -v ${PWD}:/app ghcr.io/tum-gis/ifc-to-citygml3:latest -h
 
 # Run a conversion (Linux / MacOS)
-docker run --rm -v $(pwd):/app ifc-to-citygml3 input/AC20-FZK-Haus.ifc -o output/AC20-FZK-Haus.gml --georef-oktoberfest
+docker run --rm -v $(pwd):/app ghcr.io/tum-gis/ifc-to-citygml3:latest input/AC20-FZK-Haus.ifc -o output/AC20-FZK-Haus.gml --georef-oktoberfest
 # Run a conversion (Windows Powershell)
-docker run --rm -v ${PWD}:/app ifc-to-citygml3 input/AC20-FZK-Haus.ifc -o output/AC20-FZK-Haus.gml --georef-oktoberfest
+docker run --rm -v ${PWD}:/app ghcr.io/tum-gis/ifc-to-citygml3:latest input/AC20-FZK-Haus.ifc -o output/AC20-FZK-Haus.gml --georef-oktoberfest
+```
+
+You can also build the image locally:
+
+```bash
+docker build -t ifc-to-citygml3 .
 ```
 
 **Dockerfile Overview:**


### PR DESCRIPTION
Hey Thomas,

this PR adds CI jobs for pre-built docker images. Check fork to see how this looks like:
https://github.com/BWibo/ifc-to-citygml3

**What's new:**

- Added CI workflows for automated Docker image builds using GitHub Actions
  - .github/workflows/edge.yml: Builds and pushes edge-tagged images on every push to main
  - .github/workflows/release.yml: Builds and pushes semver-tagged images (1.2.3, 1.2, 1, latest) on
 GitHub release
 - Both workflows build multi-arch images (linux/amd64, linux/arm64) and push to GHCR and DockerHub
 - Updated README with Docker image documentation: registry links, available tags, and usage examples

Required Setup

  - Add DOCKERHUB_USERNAME and DOCKERHUB_TOKEN as repository secrets